### PR TITLE
GitIgnore에 JPA Buddy Plugin의 설정 File을 무시하도록 Add

### DIFF
--- a/board-project/.gitignore
+++ b/board-project/.gitignore
@@ -4,6 +4,9 @@
 ### QueryDSL
 /src/main/generated
 
+### JPA Buddy
+.jpb/
+
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839


### PR DESCRIPTION
Intellij plugin 중 JPA 작업을 편하게 해주는 JPA Buddy라는 Plugin으로 인해 Auto 생성되는 설정 File이 Project에 포함되지 않도록 File 무시 규칙을 추가함.

This closes #19 